### PR TITLE
Named u_e in textureInfo

### DIFF
--- a/binary_templates/Astral Chain wta.bt
+++ b/binary_templates/Astral Chain wta.bt
@@ -97,6 +97,6 @@ struct {
     uint32  height;
     uint32  depth;
     uint32  u_d;
-    uint32  u_e;
+    uint32  blockHeightLog2;
     uint32  u_f<format=hex>;
 } textureInfo[header.numTex];


### PR DESCRIPTION
While trying to unswizzle images and by looking here: https://github.com/gdkchan/BnTxx/blob/master/BnTxx/Formats/BinaryTexture.cs#L92 I figured out that this value seems to be the log base 2 value of the block heights in the swizzle algorithm.